### PR TITLE
Fix a major memory leak

### DIFF
--- a/src/neural/metal/mps/MetalNetworkBuilder.h
+++ b/src/neural/metal/mps/MetalNetworkBuilder.h
@@ -60,6 +60,10 @@ public:
 
     void copyResults(std::vector<float *> output_mems);
 
+    void forwardEvalAndCopyResults(float * inputs,
+                                   int batchSize,
+                                   std::vector<float *> output_mems);
+
     void saveVariables(std::vector<std::string> names);
 
     void dumpVariables(std::vector<std::string> names, int batches);

--- a/src/neural/metal/mps/MetalNetworkBuilder.mm
+++ b/src/neural/metal/mps/MetalNetworkBuilder.mm
@@ -139,6 +139,19 @@ void MetalNetworkBuilder::copyResults(std::vector<float *> output_mems)
     [(id)self copyResultsToBuffers:&output_mems[0]];
 }
 
+void MetalNetworkBuilder::forwardEvalAndCopyResults(
+    float * inputs,
+    int batchSize,
+    std::vector<float *> output_mems)
+{
+    @autoreleasepool {
+        [(id)self runInferenceWithBatchSize:batchSize
+                                     inputs:inputs];
+
+        [(id)self copyResultsToBuffers:&output_mems[0]];
+    }
+}
+
 void MetalNetworkBuilder::saveVariables(std::vector<std::string> names)
 {
     for (const std::string name : names) {

--- a/src/neural/metal/mps/NetworkGraph.mm
+++ b/src/neural/metal/mps/NetworkGraph.mm
@@ -100,6 +100,9 @@ static const NSUInteger kMaxInflightBuffers = 4;
     _resultDataDictionary = [_graph runWithFeeds:@{_inputTensor : _inputTensorData}
                                    targetTensors:_targetTensors
                                 targetOperations:nil];
+
+    [_inputTensorData release];
+
     return _resultTensors;
 }
 

--- a/src/neural/metal/network_metal.cc
+++ b/src/neural/metal/network_metal.cc
@@ -251,12 +251,14 @@ void MetalNetwork::forwardEval(InputsOutputs* io, int batchSize) {
      */
 
     if (moves_left_) {
-      builder_->forwardEval(io->input_val_mem_expanded_, batchSize);
-      builder_->copyResults({io->op_policy_raw_mem_, io->op_value_mem_, io->op_moves_left_mem_});
+      builder_->forwardEvalAndCopyResults(
+          io->input_val_mem_expanded_, batchSize,
+          {io->op_policy_raw_mem_, io->op_value_mem_, io->op_moves_left_mem_});
     }
     else {
-      builder_->forwardEval(io->input_val_mem_expanded_, batchSize);
-      builder_->copyResults({io->op_policy_raw_mem_, io->op_value_mem_});
+      builder_->forwardEvalAndCopyResults(
+          io->input_val_mem_expanded_, batchSize,
+          {io->op_policy_raw_mem_, io->op_value_mem_});
     }
 
     // Mapping from convolutional policy to lc0 policy
@@ -273,12 +275,14 @@ void MetalNetwork::forwardEval(InputsOutputs* io, int batchSize) {
   }
   else {
     if (moves_left_) {
-      builder_->forwardEval(io->input_val_mem_expanded_, batchSize);
-      builder_->copyResults({io->op_policy_mem_, io->op_value_mem_, io->op_moves_left_mem_});
+      builder_->forwardEvalAndCopyResults(
+          io->input_val_mem_expanded_, batchSize,
+          {io->op_policy_mem_, io->op_value_mem_, io->op_moves_left_mem_});
     }
     else {
-      builder_->forwardEval(io->input_val_mem_expanded_, batchSize);
-      builder_->copyResults({io->op_policy_mem_, io->op_value_mem_});
+      builder_->forwardEvalAndCopyResults(
+          io->input_val_mem_expanded_, batchSize,
+          {io->op_policy_mem_, io->op_value_mem_});
     }
   }
 


### PR DESCRIPTION
This change fixes a major memory leak.

In this change, the input tensor data is explicitly released. And, the following functions are protected by an autorelease pool block:

- `runInferenceWithBatchSize()`
- `copyResultsToBuffers()`

In my test result, the memory usage of `lc0` becomes stable now.