### PR TITLE
Enable ARC to manage memory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -598,6 +598,8 @@ if get_option('build_backends')
     ]
 
     has_backends = true
+    add_project_arguments('-fobjc-arc', language : 'objc')
+    add_project_arguments('-fobjc-arc', language : 'objcpp')
   endif
 
 

--- a/src/neural/metal/mps/MetalNetworkBuilder.h
+++ b/src/neural/metal/mps/MetalNetworkBuilder.h
@@ -39,22 +39,7 @@ public:
 
     std::string init(int gpu_id);
 
-    void* getInputPlaceholder(int width, int height, int channels, std::string label);
-
-    void* makeConvolutionBlock(void * previousLayer, int inputSize, int channelSize, int kernelSize,
-                               float * weights, float * biases, bool withRelu, std::string label);
-
-    void* makeResidualBlock(void * previousLayer, int inputSize, int channelSize, int kernelSize,
-                            float * weights1, float * biases1, float * weights2, float * biases2,
-                            bool withRelu, std::string label, bool withSe, int seFcOutputs,
-                            float * seWeights1, float * seBiases1, float * seWeights2, float * seBiases2);
-
-    void* makeFullyConnectedLayer(void * previousLayer, int inputSize, int outputSize,
-                                  float * weights, float * biases, std::string activation, std::string label);
-
-    void* makePolicyMapLayer(void * previousLayer, uint32_t * policyMap, std::string label);
-
-    void* setSelectedOutputs(std::vector<void *> * outputs);
+    void build(int kInputPlanes, int channelSize, int kernelSize, LegacyWeights& weights, bool conv_policy, bool wdl, bool moves_left);
 
     void forwardEval(float * inputs, int batchSize, std::vector<float *> output_mems);
 
@@ -63,7 +48,7 @@ public:
     void dumpVariables(std::vector<std::string> names, int batches);
 
 private:
-    void* self;
+    int gpu_id;
 };
 
 }  // namespace metal_backend

--- a/src/neural/metal/mps/NetworkGraph.h
+++ b/src/neural/metal/mps/NetworkGraph.h
@@ -61,6 +61,11 @@ static MPSImageFeatureChannelFormat fcFormat = MPSImageFeatureChannelFormatFloat
     NSMutableDictionary<NSString *, NSObject *> * _readVariables;
 }
 
++(Lc0NetworkGraph * _Nonnull)getGraphAt:(NSNumber * _Nonnull)index;
+
++(void)initWithDevice:(id<MTLDevice> __nonnull)device
+                index:(NSNumber * _Nonnull)index;
+
 -(nonnull instancetype) initWithDevice:(id<MTLDevice> __nonnull)device;
 
 -(nonnull MPSGraphTensor *) inputPlaceholderWithInputChannels:(NSUInteger)channels
@@ -69,54 +74,37 @@ static MPSImageFeatureChannelFormat fcFormat = MPSImageFeatureChannelFormatFloat
                                                         label:(NSString * __nullable)label;
 
 -(nonnull MPSGraphTensor *) addConvolutionBlockWithParent:(MPSGraphTensor * __nonnull)parent
-                                          inputChannels:(NSUInteger)inputChannels
-                                         outputChannels:(NSUInteger)outputChannels
-                                             kernelSize:(NSUInteger)kernelSize
-                                                weights:(float * __nonnull)weights
-                                                 biases:(float * __nonnull)biases
-                                                hasRelu:(BOOL)hasRelu
-                                                  label:(NSString * __nonnull)label;
+                                            inputChannels:(NSUInteger)inputChannels
+                                           outputChannels:(NSUInteger)outputChannels
+                                               kernelSize:(NSUInteger)kernelSize
+                                                  weights:(float * __nonnull)weights
+                                                   biases:(float * __nonnull)biases
+                                                  hasRelu:(BOOL)hasRelu
+                                                    label:(NSString * __nonnull)label;
 
 -(nonnull MPSGraphTensor *) addResidualBlockWithParent:(MPSGraphTensor * __nonnull)parent
-                                       inputChannels:(NSUInteger)inputChannels
-                                      outputChannels:(NSUInteger)outputChannels
-                                          kernelSize:(NSUInteger)kernelSize
-                                            weights1:(float * __nonnull)weights1
-                                             biases1:(float * __nonnull)biases1
-                                            weights2:(float * __nonnull)weights2
-                                             biases2:(float * __nonnull)biases2
-                                               label:(NSString * __nonnull)label
-                                               hasSe:(BOOL)hasSe
-                                          seWeights1:(float * __nullable)seWeights1
-                                           seBiases1:(float * __nullable)seBiases1
-                                          seWeights2:(float * __nullable)seWeights2
-                                           seBiases2:(float * __nullable)seBiases2
-                                         seFcOutputs:(NSUInteger)seFcOutputs;
+                                         inputChannels:(NSUInteger)inputChannels
+                                        outputChannels:(NSUInteger)outputChannels
+                                            kernelSize:(NSUInteger)kernelSize
+                                              weights1:(float * __nonnull)weights1
+                                               biases1:(float * __nonnull)biases1
+                                              weights2:(float * __nonnull)weights2
+                                               biases2:(float * __nonnull)biases2
+                                                 label:(NSString * __nonnull)label
+                                                 hasSe:(BOOL)hasSe
+                                            seWeights1:(float * __nullable)seWeights1
+                                             seBiases1:(float * __nullable)seBiases1
+                                            seWeights2:(float * __nullable)seWeights2
+                                             seBiases2:(float * __nullable)seBiases2
+                                           seFcOutputs:(NSUInteger)seFcOutputs;
 
 -(nonnull MPSGraphTensor *) addFullyConnectedLayerWithParent:(MPSGraphTensor * __nonnull)parent
-                                             inputChannels:(NSUInteger)inputChannels
-                                            outputChannels:(NSUInteger)outputChannels
-                                                   weights:(float * __nonnull)weights
-                                                    biases:(float * __nonnull)biases
-                                                activation:(NSString * __nullable)activation
-                                                     label:(NSString * __nonnull)label;
-
--(nonnull MPSGraphTensor *) addSEUnitWithParent:(MPSGraphTensor * __nonnull)parent
-                                     skipNode:(MPSGraphTensor * __nonnull)skipNode
-                                inputChannels:(NSUInteger)inputChannels
-                               outputChannels:(NSUInteger)outputChannels
-                                  seFcOutputs:(NSUInteger)seFcOutputs
-                                     weights1:(float * __nonnull)weights1
-                                      biases1:(float * __nonnull)biases1
-                                     weights2:(float * __nonnull)weights2
-                                      biases2:(float * __nonnull)biases2
-                                        label:(NSString * __nonnull)label
-                                      hasRelu:(BOOL)hasRelu;
-
--(nonnull MPSGraphTensor *) addPolicyMapLayerWithParent:(MPSGraphTensor * __nonnull)parent
-                                              policyMap:(short * __nonnull)policyMap
-                                        policyMapLength:(NSUInteger)policyMapLength
-                                                  label:(NSString *)label;
+                                               inputChannels:(NSUInteger)inputChannels
+                                              outputChannels:(NSUInteger)outputChannels
+                                                     weights:(float * __nonnull)weights
+                                                      biases:(float * __nonnull)biases
+                                                  activation:(NSString * __nullable)activation
+                                                       label:(NSString * __nonnull)label;
 
 -(void) setResultTensors:(NSArray<MPSGraphTensor *> * __nonnull)results;
 

--- a/src/neural/metal/mps/NetworkGraph.mm
+++ b/src/neural/metal/mps/NetworkGraph.mm
@@ -72,6 +72,43 @@ static const NSUInteger kMaxInflightBuffers = 4;
 
 @implementation Lc0NetworkGraph
 
+// This is the Lc0NetworkGraph dictionary getter method.
+// It is a singleton object that is used to store the Lc0NetworkGraph.
++(NSMutableDictionary * _Nonnull)getGraphs {
+    // This is the Lc0NetworkGraph dictionary.
+    static NSMutableDictionary * graphs = nil;
+
+    @synchronized (self) {
+        if (graphs == nil) {
+            graphs = [NSMutableDictionary dictionaryWithCapacity:1];
+        }
+    }
+
+    return graphs;
+}
+
+// This is the Lc0NetworkGraph getter method.
++(Lc0NetworkGraph * _Nonnull)getGraphAt:(NSNumber * _Nonnull)index {
+  NSMutableDictionary * graphs = [Lc0NetworkGraph getGraphs];
+
+  return graphs[index];
+}
+
+// This is the Lc0NetworkGraph factory method.
+// It is used to create a Lc0NetworkGraph object.
+// The Lc0NetworkGraph object is stored in the dictionary.
+// The Lc0NetworkGraph object is initialized with the Metal device.
++(void)initWithDevice:(id<MTLDevice> __nonnull)device
+                index:(NSNumber * _Nonnull)index {
+    NSMutableDictionary * graphs = [Lc0NetworkGraph getGraphs];
+
+    @synchronized (self) {
+        if (graphs[index] == nil) {
+            graphs[index] = [[Lc0NetworkGraph alloc] initWithDevice:device];
+        }
+    }
+}
+
 -(nonnull instancetype) initWithDevice:(id<MTLDevice> __nonnull)device
 {
     self = [super init];
@@ -101,7 +138,6 @@ static const NSUInteger kMaxInflightBuffers = 4;
                                    targetTensors:_targetTensors
                                 targetOperations:nil];
 
-    [_inputTensorData release];
 
     return _resultTensors;
 }


### PR DESCRIPTION
**Summary**

- Enable automatic reference counting (ARC) to manage memory.

**Test**

- There are not memory leaks in the report of Xcode Profile Leaks. In fact, a memory leak is fixed by enabling the ARC.
- The overall memory usage looks stable.
- Performance is not significantly changed.
- Leela Chess Zero wins me as usual.